### PR TITLE
Fixing migration file reported by #6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,10 @@ Installation:
 4. To start using the API, you should start by using utils.get_connection(). This will use the API_KEY you
 just defined in settings.py
 
+5. To fully integrate django-mailchimp add the following line to your application's urls.py :
+
+    (r'^mailchimp/', include('mailchimp.urls')),
+
 
 Subscribing a user to a list:
 *****************************

--- a/mailchimp/migrations/0002_added_queue.py
+++ b/mailchimp/migrations/0002_added_queue.py
@@ -31,7 +31,7 @@ class Migration(SchemaMigration):
             ('tracking_html_clicks', self.gf('django.db.models.fields.BooleanField')(default=True, blank=True)),
             ('google_analytics', self.gf('django.db.models.fields.CharField')(max_length=100, null=True, blank=True)),
             ('segment_options_conditions', self.gf('django.db.models.fields.TextField')()),
-            ('template_id', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('template_id', self.gf('django.db.models.fields.IntegerField')()),
             ('tracking_opens', self.gf('django.db.models.fields.BooleanField')(default=True, blank=True)),
         ))
         db.send_create_signal('mailchimp', ['Queue'])


### PR DESCRIPTION
Hi, 
this pull request fixes the #6 issue :
django.db.utils.DatabaseError: column "template_id" cannot be cast to type smallint

Please tell me if you need anything to integrate it, i've already tested it under three linux Python 2.6.x and Django 1.3 systems.
Regards, 

Olivier.
