### PR TITLE
Added param for sending welcome message on subscribe

### DIFF
--- a/mailchimp/chimpy/chimpy.py
+++ b/mailchimp/chimpy/chimpy.py
@@ -115,13 +115,15 @@ class Connection(object):
                        email_address,
                        merge_vars,
                        email_type='text',
-                        double_optin=True):
+                       double_optin=True,
+                       send_welcome=False):
         return self._api_call(method='listSubscribe',
                               id=id,
                               email_address=email_address,
                               merge_vars=merge_vars,
                               email_type=email_type,
-                              double_optin=double_optin)
+                              double_optin=double_optin,
+                              send_welcome=send_welcome)
 
     def list_unsubscribe(self,
                          id,


### PR DESCRIPTION
Mailchimp API has a param for sending the welcome message on subscribe when doube_optin is false. Added this param to subscribe call
